### PR TITLE
Updated i18next plugin to not use the Nuxt `context.isStatic` propert…

### DIFF
--- a/src/lib/layoutServiceUtils.js
+++ b/src/lib/layoutServiceUtils.js
@@ -23,8 +23,9 @@ function getRouteData(route, language, requestClient, config, nuxtContext) {
   };
 
   if (
+    process.env.NUXT_EXPORT &&
+    process.env.NUXT_EXPORT === 'true' &&
     nuxtContext &&
-    nuxtContext.isStatic &&
     nuxtContext.app &&
     nuxtContext.app.getExportRouteDataContext
   ) {

--- a/src/plugins/sitecore-jss-i18next-plugin.js
+++ b/src/plugins/sitecore-jss-i18next-plugin.js
@@ -4,7 +4,7 @@ import axiosBackend from './i18next-axios-backend';
 import { getConfig } from '../temp/config';
 
 export default function(context) {
-  const { req, params, store, isStatic } = context;
+  const { req, params, store } = context;
 
   const config = getConfig();
 
@@ -15,7 +15,7 @@ export default function(context) {
 
   // `req` is only defined for SSR.
   // If in SSR or static export, we need to initialize i18n using the route language parameter, using the default language as fallback.
-  if (req || isStatic) {
+  if (req || (process.env.NUXT_EXPORT && process.env.NUXT_EXPORT === 'true')) {
     initValues.language = params.lang || config.defaultLanguage;
     initValues.dictionary = null;
   } else {


### PR DESCRIPTION
…y when determining if the plugin code is being executed during export. The `context.isStatic` property is true both during the export process _and_ when running/loading the static site in browser. The fix is to look for custom `NUXT_EXPORT` env var. Also adjusted other usage of the `context.isStatic` property in the project.